### PR TITLE
Rewrite Proxmox CLI in TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Node build artifacts
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # proxmox-swarm
-A simple CLI app to manage proxmox LXC like a docker swarm
+
+A simple TypeScript CLI app to manage Proxmox LXC like a Docker Swarm using the Proxmox CLI.
+
+## Usage
+
+Ensure the Proxmox CLI is installed and accessible on your system.
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Build the command-line interface:
+
+```bash
+npm run build
+```
+
+Run the command-line interface:
+
+```bash
+node dist/cli.js --host <HOST> --user <USER> --password <PASSWORD> <subcommand>
+```
+
+Available subcommands:
+
+* `deploy` – Deploy a new VM (placeholder).
+* `start <vmid>` – Start an existing VM.
+* `stop <vmid>` – Stop a running VM.
+
+Additional subcommands can be added in the future using the extensible architecture in `src/cli.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "proxmox-swarm",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "proxmox-swarm",
+      "version": "0.1.0",
+      "dependencies": {
+        "commander": "^11.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "proxmox-swarm",
+  "version": "0.1.0",
+  "description": "CLI wrapper for Proxmox in TypeScript",
+  "main": "dist/cli.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/cli.js"
+  },
+  "dependencies": {
+    "commander": "^11.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,56 @@
+import { Command } from 'commander';
+import { spawnSync } from 'child_process';
+
+const program = new Command();
+
+program
+  .name('proxmox-swarm')
+  .description('Proxmox CLI wrapper')
+  .option('--host <host>', 'Proxmox host')
+  .option('--user <user>', 'Proxmox user')
+  .option('--password <password>', 'Proxmox password');
+
+function runProxmox(cmd: string, args: string[]): void {
+  const opts = program.opts();
+  const env = {
+    ...process.env,
+    PROXMOX_HOST: opts.host,
+    PROXMOX_USER: opts.user,
+    PROXMOX_PASSWORD: opts.password,
+  } as NodeJS.ProcessEnv;
+
+  const result = spawnSync('proxmox', [cmd, ...args], {
+    stdio: 'inherit',
+    env,
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(result.status ?? 1);
+  }
+
+  process.exit(result.status ?? 0);
+}
+
+program
+  .command('deploy')
+  .description('Deploy a new VM (placeholder).')
+  .action(() => {
+    runProxmox('deploy', []);
+  });
+
+program
+  .command('start <vmid>')
+  .description('Start an existing VM.')
+  .action((vmid: string) => {
+    runProxmox('start', [vmid]);
+  });
+
+program
+  .command('stop <vmid>')
+  .description('Stop a running VM.')
+  .action((vmid: string) => {
+    runProxmox('stop', [vmid]);
+  });
+
+program.parse();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- replace Go CLI with TypeScript implementation using Commander
- execute Proxmox commands via child_process with host credentials as env vars
- document Node/TypeScript setup and update ignore rules for Node artifacts

## Testing
- `npm run build`
- `node dist/cli.js --help`
- `node dist/cli.js --host example --user root --password secret start --help`


------
https://chatgpt.com/codex/tasks/task_e_68b1bad5328883319c0a4238bdb7399d