### PR TITLE
feat: add compose parser for LXC configs

### DIFF
--- a/compose_parser.py
+++ b/compose_parser.py
@@ -1,0 +1,67 @@
+"""Parser for Docker Compose files mapping services to LXC configurations.
+
+This module leverages PyYAML to read Docker Compose YAML files and converts
+service definitions into LXC-friendly configuration objects.  It supports
+Swarm-specific extensions such as replica counts and placement constraints.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+import yaml
+
+
+@dataclass
+class LXCServiceConfig:
+    """Simplified representation of an LXC service configuration."""
+    image: str
+    ports: List[str] = field(default_factory=list)
+    environment: Dict[str, str] = field(default_factory=dict)
+    replicas: int = 1
+    constraints: List[str] = field(default_factory=list)
+
+
+def _parse_environment(env: object) -> Dict[str, str]:
+    """Normalise the environment section of a service definition."""
+    if isinstance(env, dict):
+        return {str(k): str(v) for k, v in env.items()}
+    if isinstance(env, list):
+        parsed: Dict[str, str] = {}
+        for item in env:
+            if isinstance(item, str) and "=" in item:
+                key, value = item.split("=", 1)
+                parsed[key] = value
+        return parsed
+    return {}
+
+
+def parse_compose(path: str) -> Dict[str, LXCServiceConfig]:
+    """Parse a Docker Compose file into LXC service configurations."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+
+    services = data.get("services", {})
+    configs: Dict[str, LXCServiceConfig] = {}
+
+    for name, spec in services.items():
+        image = spec.get("image", "")
+        ports = spec.get("ports", [])
+        environment = _parse_environment(spec.get("environment"))
+
+        deploy = spec.get("deploy", {})
+        replicas = deploy.get("replicas", 1)
+        placement = deploy.get("placement", {})
+        constraints = placement.get("constraints", [])
+
+        configs[name] = LXCServiceConfig(
+            image=image,
+            ports=list(ports) if isinstance(ports, list) else [],
+            environment=environment,
+            replicas=int(replicas) if isinstance(replicas, int) else 1,
+            constraints=list(constraints) if isinstance(constraints, list) else [],
+        )
+
+    return configs
+
+
+__all__ = ["LXCServiceConfig", "parse_compose"]


### PR DESCRIPTION
## Summary
- add compose_parser module reading Docker Compose with PyYAML
- expose LXCServiceConfig mapping image, ports, environment, replicas and constraints

## Testing
- `python3 -m py_compile compose_parser.py`
- `python3 -c "import compose_parser"`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1bdf3c8ac83319c9715a51abf791f