### PR TITLE
support replica deployment with options

### DIFF
--- a/src/core/daemon.ts
+++ b/src/core/daemon.ts
@@ -125,8 +125,9 @@ const server = http.createServer(async (req, res) => {
         }
 
           for (const [name, cfg] of Object.entries(services)) {
-            for (let i = 0; i < cfg.replicas; i++) {
-              const instance = cfg.replicas > 1 ? `${name}-${i + 1}` : name;
+            const replicas = cfg.replicas ?? 1;
+            for (let i = 0; i < replicas; i++) {
+              const instance = replicas > 1 ? `${name}-${i + 1}` : name;
               const status = proxmox.run('deploy', [instance, cfg.image], auth ?? {}, {
                 ports: cfg.ports,
                 environment: cfg.environment,

--- a/tests/daemon.test.ts
+++ b/tests/daemon.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import http from 'http';
+
+const runMock = vi.fn(() => 0);
+vi.mock('../src/adapters/proxmoxClient', () => ({
+  ProxmoxClient: vi.fn().mockImplementation(() => ({ run: runMock }))
+}));
+
+vi.mock('../src/services/networkService', () => ({
+  NetworkService: vi.fn().mockImplementation(() => ({ attachToSDN: vi.fn(() => 0) }))
+}));
+
+vi.mock('../src/services/storageService', () => ({
+  StorageService: vi.fn().mockImplementation(() => ({
+    createSubvolume: vi.fn(() => 0),
+    mount: vi.fn(() => 0)
+  }))
+}));
+
+vi.mock('../src/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, error: () => {}, warn: () => {} })
+}));
+
+describe('daemon deploy', () => {
+  let socketPath: string;
+  let server: any;
+
+  beforeAll(async () => {
+    const runtime = fs.mkdtempSync(join(tmpdir(), 'runtime-'));
+    process.env.XDG_RUNTIME_DIR = runtime;
+    process.env.SWARM_LOG_FILE = join(runtime, 'daemon.log');
+    process.env.SWARM_LOG_INTERVAL = 'daily';
+    ({ socketFile: socketPath } = await import('../src/core/runtime'));
+    ({ server } = await import('../src/core/daemon'));
+  });
+
+  afterAll(() => {
+    server.close();
+    if (process.env.XDG_RUNTIME_DIR) {
+      fs.rmSync(process.env.XDG_RUNTIME_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it('creates multiple containers and passes options', async () => {
+    const yaml = `services:\n  app:\n    image: img\n    ports: ['80:80']\n    environment:\n      NODE_ENV: test\n    deploy:\n      replicas: 2\nvolumes: {}`;
+    const dir = fs.mkdtempSync(join(tmpdir(), 'compose-'));
+    const file = join(dir, 'compose.yml');
+    fs.writeFileSync(file, yaml);
+    const body = JSON.stringify({ compose: file });
+
+    await new Promise<void>((resolve) => {
+      const req = http.request({
+        socketPath,
+        path: '/deploy',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      }, (res) => {
+        res.on('data', () => {});
+        res.on('end', resolve);
+      });
+      req.write(body);
+      req.end();
+    });
+
+    expect(runMock).toHaveBeenCalledTimes(2);
+    for (const call of runMock.mock.calls) {
+      expect(call[3]).toEqual({ ports: ['80:80'], environment: { NODE_ENV: 'test' } });
+    }
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/proxmoxClient.test.ts
+++ b/tests/proxmoxClient.test.ts
@@ -11,11 +11,12 @@ describe('ProxmoxClient', () => {
   it('runs proxmox with provided auth', () => {
     const client = new ProxmoxClient();
     const auth = { host: 'h', user: 'u', password: 'p' };
-    const status = client.run('cmd', ['arg'], auth);
+    const opts = { ports: ['80:80'], environment: { NODE_ENV: 'prod' } };
+    const status = client.run('cmd', ['arg'], auth, opts);
     expect(status).toBe(0);
     expect(spawnSync).toHaveBeenCalledWith(
       'proxmox',
-      ['cmd', 'arg'],
+      ['cmd', 'arg', '-p', '80:80', '-e', 'NODE_ENV=prod'],
       expect.objectContaining({
         stdio: 'inherit',
         env: expect.objectContaining({


### PR DESCRIPTION
## Summary
- support passing ports and env vars when deploying via Proxmox client
- deploy service replicas and attach volumes/network per instance
- test replica deployment and option forwarding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b20bcbd01883319cb25664830d6a32