### PR TITLE
feat: use non-blocking pid file waits

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+vi.mock('../src/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, error: () => {} }),
+}));
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({ unref: () => {} })),
+}));
+
+describe('cli daemon start', () => {
+  let runtime: string;
+  let pidFile: string;
+
+  beforeAll(async () => {
+    runtime = fs.mkdtempSync(join(tmpdir(), 'runtime-'));
+    process.env.XDG_RUNTIME_DIR = runtime;
+    ({ pidFile } = await import('../src/core/runtime'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(runtime, { recursive: true, force: true });
+  });
+
+  it('does not block the event loop while waiting for pid file', async () => {
+    const { startDaemon } = await import('../src/commands/cli');
+    let fired = false;
+    setTimeout(() => {
+      fired = true;
+      fs.writeFileSync(pidFile, String(process.pid));
+    }, 50);
+    await startDaemon();
+    expect(fired).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace blocking daemon start/stop loops with async file watchers
- run CLI parsing only when executed as a script
- test that daemon start waits without blocking the event loop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20e9f14b883319398979b17c2a520