### PR TITLE
feat(network): extend SDN management

### DIFF
--- a/src/adapters/proxmoxClient.ts
+++ b/src/adapters/proxmoxClient.ts
@@ -13,6 +13,7 @@ export interface ProxmoxRunOptions {
 
 export interface IProxmoxClient {
   run(cmd: string, args: string[], auth: ProxmoxAuth, options?: ProxmoxRunOptions): number;
+  sdn(args: string[], auth: ProxmoxAuth, options?: ProxmoxRunOptions): number;
 }
 
 export class ProxmoxClient implements IProxmoxClient {
@@ -47,6 +48,10 @@ export class ProxmoxClient implements IProxmoxClient {
     }
 
     return result.status ?? 0;
+  }
+
+  sdn(args: string[], auth: ProxmoxAuth, options: ProxmoxRunOptions = {}): number {
+    return this.run('sdn', args, auth, options);
   }
 }
 

--- a/src/services/networkService.ts
+++ b/src/services/networkService.ts
@@ -56,7 +56,7 @@ export class NetworkService implements INetworkService {
     vlan?: number
   ): number {
     const args = ['create', name];
-    if (zone) {
+    if (zone !== undefined) {
       args.push('--zone', zone);
     }
     if (vlan !== undefined) {
@@ -77,7 +77,7 @@ export class NetworkService implements INetworkService {
     acls?: string[]
   ): number {
     const args = ['iface', iface];
-    if (ip) {
+    if (ip !== undefined) {
       args.push('--ip', ip);
     }
     if (mtu !== undefined) {

--- a/src/services/networkService.ts
+++ b/src/services/networkService.ts
@@ -8,6 +8,21 @@ export interface INetworkService {
     tags?: string[],
     vlan?: number
   ): number;
+  detachFromSDN(auth: ProxmoxAuth, vmid: string, network: string): number;
+  createNetwork(
+    auth: ProxmoxAuth,
+    name: string,
+    zone?: string,
+    vlan?: number
+  ): number;
+  deleteNetwork(auth: ProxmoxAuth, name: string): number;
+  configureInterface(
+    auth: ProxmoxAuth,
+    iface: string,
+    ip?: string,
+    mtu?: number,
+    acls?: string[]
+  ): number;
 }
 
 export class NetworkService implements INetworkService {
@@ -27,7 +42,51 @@ export class NetworkService implements INetworkService {
     if (vlan !== undefined) {
       args.push('--vlan', String(vlan));
     }
-    return this.proxmox.run('sdn', args, auth);
+    return this.proxmox.sdn(args, auth);
+  }
+
+  detachFromSDN(auth: ProxmoxAuth, vmid: string, network: string): number {
+    return this.proxmox.sdn(['detach', vmid, network], auth);
+  }
+
+  createNetwork(
+    auth: ProxmoxAuth,
+    name: string,
+    zone?: string,
+    vlan?: number
+  ): number {
+    const args = ['create', name];
+    if (zone) {
+      args.push('--zone', zone);
+    }
+    if (vlan !== undefined) {
+      args.push('--vlan', String(vlan));
+    }
+    return this.proxmox.sdn(args, auth);
+  }
+
+  deleteNetwork(auth: ProxmoxAuth, name: string): number {
+    return this.proxmox.sdn(['delete', name], auth);
+  }
+
+  configureInterface(
+    auth: ProxmoxAuth,
+    iface: string,
+    ip?: string,
+    mtu?: number,
+    acls?: string[]
+  ): number {
+    const args = ['iface', iface];
+    if (ip) {
+      args.push('--ip', ip);
+    }
+    if (mtu !== undefined) {
+      args.push('--mtu', String(mtu));
+    }
+    if (acls && acls.length) {
+      args.push('--acl', acls.join(','));
+    }
+    return this.proxmox.sdn(args, auth);
   }
 }
 

--- a/tests/networkService.test.ts
+++ b/tests/networkService.test.ts
@@ -3,19 +3,60 @@ import { NetworkService } from '../src/services/networkService';
 
 describe('NetworkService', () => {
   it('attaches without tags or vlan', () => {
-    const run = vi.fn().mockReturnValue(0);
-    const svc = new NetworkService({ run } as any);
+    const sdn = vi.fn().mockReturnValue(0);
+    const svc = new NetworkService({ sdn } as any);
     const auth = { host: 'h' };
     const status = svc.attachToSDN(auth, '100', 'net');
     expect(status).toBe(0);
-    expect(run).toHaveBeenCalledWith('sdn', ['attach', '100', 'net'], auth);
+    expect(sdn).toHaveBeenCalledWith(['attach', '100', 'net'], auth);
   });
 
   it('attaches with tags and vlan', () => {
-    const run = vi.fn().mockReturnValue(0);
-    const svc = new NetworkService({ run } as any);
+    const sdn = vi.fn().mockReturnValue(0);
+    const svc = new NetworkService({ sdn } as any);
     const auth = {};
     svc.attachToSDN(auth, '101', 'net', ['a', 'b'], 5);
-    expect(run).toHaveBeenCalledWith('sdn', ['attach', '101', 'net', '--tags', 'a,b', '--vlan', '5'], auth);
+    expect(sdn).toHaveBeenCalledWith(
+      ['attach', '101', 'net', '--tags', 'a,b', '--vlan', '5'],
+      auth
+    );
+  });
+
+  it('detaches from network', () => {
+    const sdn = vi.fn().mockReturnValue(0);
+    const svc = new NetworkService({ sdn } as any);
+    const auth = {};
+    svc.detachFromSDN(auth, '102', 'net');
+    expect(sdn).toHaveBeenCalledWith(['detach', '102', 'net'], auth);
+  });
+
+  it('creates network with zone and vlan', () => {
+    const sdn = vi.fn().mockReturnValue(0);
+    const svc = new NetworkService({ sdn } as any);
+    const auth = {};
+    svc.createNetwork(auth, 'net', 'zone1', 10);
+    expect(sdn).toHaveBeenCalledWith(
+      ['create', 'net', '--zone', 'zone1', '--vlan', '10'],
+      auth
+    );
+  });
+
+  it('deletes network', () => {
+    const sdn = vi.fn().mockReturnValue(0);
+    const svc = new NetworkService({ sdn } as any);
+    const auth = {};
+    svc.deleteNetwork(auth, 'net');
+    expect(sdn).toHaveBeenCalledWith(['delete', 'net'], auth);
+  });
+
+  it('configures interface', () => {
+    const sdn = vi.fn().mockReturnValue(0);
+    const svc = new NetworkService({ sdn } as any);
+    const auth = {};
+    svc.configureInterface(auth, 'eth0', '10.0.0.2/24', 1500, ['a', 'b']);
+    expect(sdn).toHaveBeenCalledWith(
+      ['iface', 'eth0', '--ip', '10.0.0.2/24', '--mtu', '1500', '--acl', 'a,b'],
+      auth
+    );
   });
 });

--- a/tests/networkService.test.ts
+++ b/tests/networkService.test.ts
@@ -41,6 +41,17 @@ describe('NetworkService', () => {
     );
   });
 
+  it('creates network with empty zone string', () => {
+    const sdn = vi.fn().mockReturnValue(0);
+    const svc = new NetworkService({ sdn } as any);
+    const auth = {};
+    svc.createNetwork(auth, 'net', '', 5);
+    expect(sdn).toHaveBeenCalledWith(
+      ['create', 'net', '--zone', '', '--vlan', '5'],
+      auth
+    );
+  });
+
   it('deletes network', () => {
     const sdn = vi.fn().mockReturnValue(0);
     const svc = new NetworkService({ sdn } as any);
@@ -56,6 +67,17 @@ describe('NetworkService', () => {
     svc.configureInterface(auth, 'eth0', '10.0.0.2/24', 1500, ['a', 'b']);
     expect(sdn).toHaveBeenCalledWith(
       ['iface', 'eth0', '--ip', '10.0.0.2/24', '--mtu', '1500', '--acl', 'a,b'],
+      auth
+    );
+  });
+
+  it('configures interface with empty ip string', () => {
+    const sdn = vi.fn().mockReturnValue(0);
+    const svc = new NetworkService({ sdn } as any);
+    const auth = {};
+    svc.configureInterface(auth, 'eth0', '');
+    expect(sdn).toHaveBeenCalledWith(
+      ['iface', 'eth0', '--ip', ''],
       auth
     );
   });


### PR DESCRIPTION
## Summary
- add Proxmox client helper for SDN subcommands
- support detach, create, delete, and interface configuration in network service
- test new network operations and argument passing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21479bd6c8331b17244b781a38990