### PR TITLE
feat: validate network params

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Available subcommands:
 When `--sdn-network` is specified, newly created containers are attached to the
 given overlay network using the Proxmox SDN API. Network tags and VLAN IDs can
 be defined per service in the compose file via `tags` and `vlan` fields. VLAN IDs
-must be integers between 0 and 4094.
+must be integers between 1 and 4094.
 
 CephFS subvolumes can be defined in the compose file's `volumes` section. These
 subvolumes are created (if necessary) during deployment and mounted into each

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ When `--sdn-network` is specified, newly created containers are attached to the
 given overlay network using the Proxmox SDN API. Network tags and VLAN IDs can
 be defined per service in the compose file via `tags` and `vlan` fields. VLAN IDs
 must be integers between 1 and 4094.
+The current system uses SDN in vxlan mode with overlay addresses in the 172.16.0.0/12 range.
 
 CephFS subvolumes can be defined in the compose file's `volumes` section. These
 subvolumes are created (if necessary) during deployment and mounted into each

--- a/src/services/networkService.ts
+++ b/src/services/networkService.ts
@@ -1,5 +1,22 @@
 import { IProxmoxClient, ProxmoxAuth } from '../adapters/proxmoxClient';
 
+const TAG_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+function validateTagsAndVlan(tags?: string[], vlan?: number): void {
+  if (tags) {
+    for (const tag of tags) {
+      if (!TAG_REGEX.test(tag)) {
+        throw new Error(`Invalid tag format: ${tag}`);
+      }
+    }
+  }
+  if (vlan !== undefined) {
+    if (!Number.isInteger(vlan) || vlan < 1 || vlan > 4094) {
+      throw new Error('VLAN must be an integer between 1 and 4094');
+    }
+  }
+}
+
 export interface INetworkService {
   attachToSDN(
     auth: ProxmoxAuth,
@@ -35,6 +52,7 @@ export class NetworkService implements INetworkService {
     tags?: string[],
     vlan?: number
   ): number {
+    validateTagsAndVlan(tags, vlan);
     const args = ['attach', vmid, network];
     if (tags && tags.length) {
       args.push('--tags', tags.join(','));
@@ -55,6 +73,7 @@ export class NetworkService implements INetworkService {
     zone?: string,
     vlan?: number
   ): number {
+    validateTagsAndVlan(undefined, vlan);
     const args = ['create', name];
     if (zone !== undefined) {
       args.push('--zone', zone);

--- a/tests/networkService.test.ts
+++ b/tests/networkService.test.ts
@@ -52,6 +52,26 @@ describe('NetworkService', () => {
     );
   });
 
+  it('throws error for invalid tag format', () => {
+    const sdn = vi.fn();
+    const svc = new NetworkService({ sdn } as any);
+    const auth = {};
+    expect(() => svc.attachToSDN(auth, '103', 'net', ['bad tag'])).toThrow(
+      /Invalid tag format/
+    );
+    expect(sdn).not.toHaveBeenCalled();
+  });
+
+  it('throws error for vlan out of range', () => {
+    const sdn = vi.fn();
+    const svc = new NetworkService({ sdn } as any);
+    const auth = {};
+    expect(() => svc.createNetwork(auth, 'net', 'zone', 5000)).toThrow(
+      /VLAN must be an integer between 1 and 4094/
+    );
+    expect(sdn).not.toHaveBeenCalled();
+  });
+
   it('deletes network', () => {
     const sdn = vi.fn().mockReturnValue(0);
     const svc = new NetworkService({ sdn } as any);


### PR DESCRIPTION
## Summary
- validate network tags and VLAN range in NetworkService
- document VLAN range 1-4094
- add tests for invalid tags and VLAN IDs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b217d1af2483319ca492e481c51dbe