### PR TITLE
feat(storage): add CephFS unmount and subvolume removal

### DIFF
--- a/tests/storageService.test.ts
+++ b/tests/storageService.test.ts
@@ -23,4 +23,30 @@ describe('StorageService', () => {
       auth
     );
   });
+
+  it('unmounts with options', () => {
+    const run = vi.fn().mockReturnValue(0);
+    const svc = new StorageService({ run } as any);
+    const auth = {};
+    const status = svc.unmount(auth, '101', '/data', { force: '1', bad: 'x' } as any);
+    expect(status).toBe(0);
+    expect(run).toHaveBeenCalledWith(
+      'cephfs',
+      ['umount', '101', '/data', '--force', '1'],
+      auth
+    );
+  });
+
+  it('removes subvolume with options', () => {
+    const run = vi.fn().mockReturnValue(0);
+    const svc = new StorageService({ run } as any);
+    const auth = {};
+    const status = svc.removeSubvolume(auth, 'subvol', { force: '1', bad: 'x' } as any);
+    expect(status).toBe(0);
+    expect(run).toHaveBeenCalledWith(
+      'cephfs',
+      ['subvolume', 'rm', 'subvol', '--force', '1'],
+      auth
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- support `cephfs umount` and `cephfs subvolume rm` in StorageService
- expose `unmount` and `removeSubvolume` methods in IStorageService
- test that unmount and removeSubvolume pass proper options to Proxmox

## Testing
- `npm test`
- `npm run build` *(fails: TS6059 files not under rootDir)*

------
https://chatgpt.com/codex/tasks/task_e_68b21a3c00fc8331bd194b9a18459a9a