### PR TITLE
feat(storage): document and support extra CephFS options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,4 +128,10 @@ Volumes marked `external: true` are referenced but not created during deployment
 Only a limited set of safe CephFS options is passed to the underlying CLI; any
 unsupported keys are ignored.
 
+Supported subvolume options: `size`, `mode`, `uid`, `gid`, `quota`, and
+`compression`.
+
+Supported mount options: `uid`, `gid`, `rw`, `ro`, `quota`, `atime`, `noatime`,
+and `cache-size`.
+
 Additional subcommands can be added in the future using the extensible architecture in `src/cli.ts`.

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -28,8 +28,24 @@ export interface IStorageService {
 }
 
 export class StorageService implements IStorageService {
-  private readonly allowedSubvolumeOptions = new Set(['size', 'mode', 'uid', 'gid', 'quota']);
-  private readonly allowedMountOptions = new Set(['uid', 'gid', 'rw', 'ro', 'quota']);
+  private readonly allowedSubvolumeOptions = new Set([
+    'size',
+    'mode',
+    'uid',
+    'gid',
+    'quota',
+    'compression',
+  ]);
+  private readonly allowedMountOptions = new Set([
+    'uid',
+    'gid',
+    'rw',
+    'ro',
+    'quota',
+    'atime',
+    'noatime',
+    'cache-size',
+  ]);
   private readonly allowedUnmountOptions = new Set(['force']);
   private readonly allowedRemoveSubvolumeOptions = new Set(['force']);
 

--- a/tests/storageService.test.ts
+++ b/tests/storageService.test.ts
@@ -6,20 +6,46 @@ describe('StorageService', () => {
     const run = vi.fn().mockReturnValue(0);
     const svc = new StorageService({ run } as any);
     const auth = {};
-    const status = svc.createSubvolume(auth, 'subvol', { size: '1G', invalid: 'x' } as any);
+    const status = svc.createSubvolume(auth, 'subvol', {
+      size: '1G',
+      compression: 'lz4',
+      invalid: 'x',
+    } as any);
     expect(status).toBe(0);
-    expect(run).toHaveBeenCalledWith('cephfs', ['subvolume', 'create', 'subvol', '--size', '1G'], auth);
+    expect(run).toHaveBeenCalledWith(
+      'cephfs',
+      ['subvolume', 'create', 'subvol', '--size', '1G', '--compression', 'lz4'],
+      auth
+    );
   });
 
   it('mounts with mode and options', () => {
     const run = vi.fn().mockReturnValue(0);
     const svc = new StorageService({ run } as any);
     const auth = {};
-    const status = svc.mount(auth, '101', '/data', 'subvol', 'rw', { uid: '1000', bad: 'x' } as any);
+    const status = svc.mount(
+      auth,
+      '101',
+      '/data',
+      'subvol',
+      'rw',
+      { uid: '1000', noatime: '1', bad: 'x' } as any
+    );
     expect(status).toBe(0);
     expect(run).toHaveBeenCalledWith(
       'cephfs',
-      ['mount', '101', '/data', 'subvol', '--mode', 'rw', '--uid', '1000'],
+      [
+        'mount',
+        '101',
+        '/data',
+        'subvol',
+        '--mode',
+        'rw',
+        '--uid',
+        '1000',
+        '--noatime',
+        '1',
+      ],
       auth
     );
   });


### PR DESCRIPTION
## Summary
- document allowed CephFS subvolume and mount options
- allow additional CephFS options like compression and atime/noatime
- test new CephFS option handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b21d27f0248331a7b3487e596f6d38