### PR TITLE
Add negative and integration workflow tests

### DIFF
--- a/tests/integrationFlow.test.ts
+++ b/tests/integrationFlow.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { StorageService } from '../src/services/storageService';
+import { NetworkService } from '../src/services/networkService';
+
+describe('Integration workflow', () => {
+  it('creates subvolume, mounts, attaches network, then cleans up', () => {
+    const run = vi.fn().mockReturnValue(0);
+    const sdn = vi.fn().mockReturnValue(0);
+    const proxmox = { run, sdn } as any;
+    const storage = new StorageService(proxmox);
+    const network = new NetworkService(proxmox);
+    const auth = {};
+
+    expect(storage.createSubvolume(auth, 'sv')).toBe(0);
+    expect(storage.mount(auth, '100', '/mnt', 'sv')).toBe(0);
+    expect(network.attachToSDN(auth, '100', 'net')).toBe(0);
+    expect(storage.unmount(auth, '100', '/mnt')).toBe(0);
+    expect(network.detachFromSDN(auth, '100', 'net')).toBe(0);
+
+    expect(run).toHaveBeenNthCalledWith(1, 'cephfs', ['subvolume', 'create', 'sv'], auth);
+    expect(run).toHaveBeenNthCalledWith(2, 'cephfs', ['mount', '100', '/mnt', 'sv'], auth);
+    expect(run).toHaveBeenNthCalledWith(3, 'cephfs', ['umount', '100', '/mnt'], auth);
+    expect(sdn).toHaveBeenNthCalledWith(1, ['attach', '100', 'net'], auth);
+    expect(sdn).toHaveBeenNthCalledWith(2, ['detach', '100', 'net'], auth);
+  });
+});

--- a/tests/networkService.test.ts
+++ b/tests/networkService.test.ts
@@ -101,4 +101,16 @@ describe('NetworkService', () => {
       auth
     );
   });
+
+  it('propagates non-zero status from sdn operations', () => {
+    const sdn = vi.fn().mockReturnValue(1);
+    const svc = new NetworkService({ sdn } as any);
+    const auth = {};
+
+    expect(svc.attachToSDN(auth, '200', 'net')).toBe(1);
+    expect(svc.detachFromSDN(auth, '200', 'net')).toBe(1);
+    expect(svc.createNetwork(auth, 'net')).toBe(1);
+    expect(svc.deleteNetwork(auth, 'net')).toBe(1);
+    expect(svc.configureInterface(auth, 'eth0')).toBe(1);
+  });
 });

--- a/tests/proxmoxClient.test.ts
+++ b/tests/proxmoxClient.test.ts
@@ -34,4 +34,11 @@ describe('ProxmoxClient', () => {
     const status = client.run('cmd', [], {});
     expect(status).toBe(1);
   });
+
+  it('propagates non-zero exit status', () => {
+    (spawnSync as any).mockReturnValueOnce({ status: 2 });
+    const client = new ProxmoxClient();
+    const status = client.run('cmd', [], {});
+    expect(status).toBe(2);
+  });
 });

--- a/tests/storageService.test.ts
+++ b/tests/storageService.test.ts
@@ -49,4 +49,15 @@ describe('StorageService', () => {
       auth
     );
   });
+
+  it('propagates non-zero status from run operations', () => {
+    const run = vi.fn().mockReturnValue(1);
+    const svc = new StorageService({ run } as any);
+    const auth = {};
+
+    expect(svc.createSubvolume(auth, 'sv')).toBe(1);
+    expect(svc.mount(auth, '101', '/data', 'sv')).toBe(1);
+    expect(svc.unmount(auth, '101', '/data')).toBe(1);
+    expect(svc.removeSubvolume(auth, 'sv')).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for non-zero exit propagation in proxmox client, network and storage services
- add integration test covering subvolume creation, mount, network attach and cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21d676b448331ac39e042e3359f26